### PR TITLE
chore: build migration images

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -46,6 +46,7 @@ jobs:
         image: ${{ env.IMAGE_NAME }}
         tags: latest ${{ github.sha }} ${{ github.ref_name }}
         containerfiles: ./Dockerfile
+        layers: true
 
     - name: Log in to the GitHub Container registry
       uses: redhat-actions/podman-login@v1

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,6 +20,16 @@ jobs:
     - name: Clone the repository
       uses: actions/checkout@v3
 
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Run tests
       run: cargo test
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,4 +1,4 @@
-name: Build Container
+name: Build images
 on:
   push:
     branches:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build image
+    name: Build images
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: ${{ github.event.repository.name }}
@@ -39,13 +39,36 @@ jobs:
     - name: Run fmt
       run: cargo fmt --check
 
-    - name: Buildah Action
+    - name: Normalize tags
+      id: norm-tags
+      run: |
+        TAGS=$(echo latest ${{ github.sha }} ${{ github.ref_name }} | tr "/" "-")
+        echo "TAGS: $TAGS"
+        echo "tags=$TAGS" > $GITHUB_OUTPUT
+
+    - name: Normalize migration tags
+      id: norm-migration-tags
+      run: |
+        TAGS=$(echo latest-migration ${{ github.sha }}-migration ${{ github.ref_name }}-migration | tr "/" "-")
+        echo "MIGRATION TAGS: $TAGS"
+        echo "tags=$TAGS" > $GITHUB_OUTPUT
+
+    - name: Build application image
       id: build-image
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
-        tags: latest ${{ github.sha }} ${{ github.ref_name }}
+        tags: ${{ steps.norm-tags.outputs.tags }}
         containerfiles: ./Dockerfile
+        layers: true
+
+    - name: Build migration image
+      id: build-migration-image
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.IMAGE_NAME }}
+        tags: ${{ steps.norm-migration-tags.outputs.tags }}
+        containerfiles: ./sqlx-cli.Dockerfile
         layers: true
 
     - name: Log in to the GitHub Container registry
@@ -64,5 +87,5 @@ jobs:
       uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
-        tags: ${{ steps.build-image.outputs.tags }}
+        tags: ${{ steps.build-image.outputs.tags }} ${{ steps.build-migration-image.outputs.tags }}
         registry: ${{ env.REGISTRY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
     - run: rustup toolchain list
     - run: cargo --version
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,6 @@ RUN cargo install --locked --path .
 RUN ls -lah /usr/local/cargo/bin
 
 
-FROM builder as migrations
-RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
-
-
 FROM debian:bookworm-slim
 # RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local/cargo/bin/robserver /usr/local/bin/robserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM rust:1.73-bookworm as builder
 WORKDIR /usr/src/app
 
 COPY . .
-RUN cargo install --path .
+RUN cargo install --locked --path .
 RUN ls -lah /usr/local/cargo/bin
+
+
+FROM builder as migrations
+RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
+
 
 FROM debian:bookworm-slim
 # RUN apt-get update && apt-get install -y extra-runtime-dependencies && rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -17,16 +17,30 @@ Then if you have `cargo` installed locally:
 export DATABASE_URL="postgres://postgres@127.0.0.1/robserver"
 export ROBSERVER_AMQP_ADDR="amqp://guest:guest@127.0.0.1:5672/%2f"
 
-cargo sqlx database create
-cargo sqlx migrate run
-
 cargo run
 ```
 
 Or run it as a container(the image is under 100mb):
 
 ```bash
-podman run --rm -it --network host -e DATABASE_URL="postgres://postgres@127.0.0.1/robserver" -e ROBSERVER_AMQP_ADDR="amqp://guest:guest@127.0.0.1:5672/%2f" --name robserver ghcr.io/rauno56/robserver:v1.2.0
+podman run --rm -it --name robserver --network host -e DATABASE_URL="postgres://postgres@127.0.0.1/robserver" -e ROBSERVER_AMQP_ADDR="amqp://guest:guest@127.0.0.1:5672/%2f" ghcr.io/rauno56/robserver:latest
+```
+
+## Running migrations
+
+Above example uses a feature build into postgres docker images to run migrations on startup. If you don't have that possibility, you must run the migrations before starting robserver service. If you have `cargo` installed locally:
+
+```bash
+export DATABASE_URL="postgres://postgres@127.0.0.1/robserver"
+
+cargo sqlx database create
+cargo sqlx migrate run
+```
+
+... if not, you can use a prebuild docker image:
+
+```bash
+podman run --rm -it --name robserver-migration --network host -e DATABASE_URL="postgres://postgres@127.0.0.1/robserver" ghcr.io/rauno56/robserver:latest-migration
 ```
 
 ## Configuration

--- a/scripts/sqlx-create-run
+++ b/scripts/sqlx-create-run
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+cargo sqlx database create || exit 1
+cargo sqlx migrate run

--- a/sqlx-cli.Dockerfile
+++ b/sqlx-cli.Dockerfile
@@ -1,0 +1,10 @@
+FROM rust:1.73-bookworm as builder
+WORKDIR /usr/src/app
+
+RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
+RUN rm -rf $CARGO_HOME/registry
+
+COPY migrations migrations
+COPY scripts/sqlx-create-run sqlx-create-run
+
+CMD ["bash", "sqlx-create-run"]


### PR DESCRIPTION
- chore: cache cargo deps in between builds
- chore: install sqlx cli as a dockerfile step to provide image for migrations
- chore: enable layer caching for buildah
